### PR TITLE
create CJS version of ESM code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,28 @@
+async function convert(markdown) {
+  const { unified } = await import('unified');
+  const remarkParse = await import('remark-parse');
+  const remarkVscode = await import('gatsby-remark-vscode');
+  const rehypeRaw = await import('rehype-raw');
+  const remarkToRehype = await import('remark-rehype');
+  const remarkGfm = await import('remark-gfm');
+  const rehypeStringify = await import('rehype-stringify');
+  const remarkCodeTitles = await import('remark-code-titles');
+
+  const processor = unified()
+    .use(remarkParse.default)
+    .use(remarkGfm.default)
+    .use(remarkCodeTitles.default)
+    .use(remarkVscode.default.remarkPlugin, {
+      theme: 'Cobalt2',
+      extensions: [`theme-cobalt2`],
+    })
+    .use(remarkToRehype.default, { allowDangerousHtml: true })
+    .use(rehypeRaw.default)
+    .use(rehypeStringify.default)
+
+  const file = await processor.process(markdown)
+
+  return file.value;
+}
+
+module.exports = { convert };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@wesbos/markdown-to-html",
   "version": "1.1.0",
   "description": "Converts Markdown to HTML with Wes Bos' Cobalt 2 theme. To be used on the server",
-  "type": "module",
   "main": "index.mjs",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Converts Markdown to HTML with Wes Bos' Cobalt 2 theme. To be used on the server",
   "type": "module",
   "main": "index.mjs",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.js"
+    }
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This adds a CJS version to the existing ESM version.

The `"exports"` key will tell the code editor which file to import the code from.